### PR TITLE
fix: copy 128/256-pixel icons into hicolor so Plasma finds them

### DIFF
--- a/packages/windsurf/PKGBUILD
+++ b/packages/windsurf/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=windsurf
 pkgver=1.7.1
-pkgrel=1
+pkgrel=2
 pkgdesc="The new purpose-built IDE to harness magic"
 arch=('x86_64')
 url="https://windsurf.com/"
@@ -69,7 +69,16 @@ package() {
     # Install application metadata (AppStream metainfo)
     install -Dm644 "usr/share/appdata/${pkgname}.appdata.xml" "${pkgdir}/usr/share/metainfo/com.codeium.${pkgname}.metainfo.xml"
     install -Dm644 "usr/share/mime/packages/${pkgname}-workspace.xml" "${pkgdir}/usr/share/mime/packages/${pkgname}-workspace.xml"
-    install -Dm644 "usr/share/pixmaps/${pkgname}.png" "${pkgdir}/usr/share/icons/hicolor/1024x1024/apps/${pkgname}.png"
+    # KDE/GTK never look in 1024-px dirs; install smaller aliases too
+    local _icon="usr/share/pixmaps/${pkgname}.png"
+
+    # install the real file once (1024 px)
+    install -Dm644 "${_icon}" "${pkgdir}/usr/share/icons/hicolor/1024x1024/apps/${pkgname}.png"
+
+    # create 256 px & 128 px entries as symlinks to save space
+    for _sz in 256 128; do
+        ln -s "/usr/share/icons/hicolor/1024x1024/apps/${pkgname}.png" "${pkgdir}/usr/share/icons/hicolor/${_sz}x${_sz}/apps/${pkgname}.png"
+    done
 	# Shell completions
     mv "usr/share/bash-completion" "${pkgdir}/usr/share/bash-completion"
     install -Dm 644 "usr/share/zsh/vendor-completions/_${pkgname}" "${pkgdir}/usr/share/zsh/site-functions/_${pkgname}"

--- a/packages/windsurf/PKGBUILD
+++ b/packages/windsurf/PKGBUILD
@@ -77,6 +77,7 @@ package() {
 
     # create 256 px & 128 px entries as symlinks to save space
     for _sz in 256 128; do
+        install -d "${pkgdir}/usr/share/icons/hicolor/${_sz}x${_sz}/apps"
         ln -s "/usr/share/icons/hicolor/1024x1024/apps/${pkgname}.png" "${pkgdir}/usr/share/icons/hicolor/${_sz}x${_sz}/apps/${pkgname}.png"
     done
 	# Shell completions


### PR DESCRIPTION
KDE/GTK icon loaders stop at 512 px and never check the 1024x1024 hicolor directory.
This patch:

- installs the 1024 × 1024 PNG once, then symlinks it into 256x256 and 128x128 (package() loop) so Plasma-based desktops find the icon;
- bumps pkgrel to 2;
- touches nothing else (sources and checksums unchanged).

Using symlinks keeps the package size the same while restoring the application icon in Kickoff, task-manager, etc.






