### PR TITLE
Fix makepkg --repackage

### DIFF
--- a/packages/windsurf/PKGBUILD
+++ b/packages/windsurf/PKGBUILD
@@ -52,11 +52,8 @@ source=("https://windsurf-stable.codeiumdata.com/wVxQEIWkwPUEAGf3/apt/pool/main/
 
 sha256sums=('4cf3c79d802eda606ce155339775bec06d1bfe5e1d7d92eed44a7e317c1611a4')
 
-prepare() {
-    bsdtar -xf "data.tar.xz"
-}
-
 package() {
+    bsdtar -xf "data.tar.xz"
     # Install main binaries
     install -d "${pkgdir}/usr/share/${pkgname}"
     mv "usr/share/${pkgname}" "${pkgdir}/usr/share/"
@@ -72,5 +69,5 @@ package() {
     install -Dm644 "usr/share/pixmaps/${pkgname}.png" "${pkgdir}/usr/share/icons/hicolor/1024x1024/apps/${pkgname}.png"
 	# Shell completions
     mv "usr/share/bash-completion" "${pkgdir}/usr/share/bash-completion"
-    install -Dm 644 "usr/share/zsh/vendor-completions/_${pkgname}" "${pkgdir}/usr/share/zsh/site-functions/_${pkgname}"
+    install -Dm644 "usr/share/zsh/vendor-completions/_${pkgname}" "${pkgdir}/usr/share/zsh/site-functions/_${pkgname}"
 }

--- a/packages/windsurf/PKGBUILD
+++ b/packages/windsurf/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Chris Watson <cawatson1993@gmail.com>
 
 pkgname=windsurf
-pkgver=1.7.1
+pkgver=1.7.2
 pkgrel=1
 pkgdesc="The new purpose-built IDE to harness magic"
 arch=('x86_64')
@@ -50,7 +50,7 @@ options=('!strip')
 
 source=("https://windsurf-stable.codeiumdata.com/wVxQEIWkwPUEAGf3/apt/pool/main/w/windsurf/Windsurf-linux-x64-${pkgver}.deb")
 
-sha256sums=('4cf3c79d802eda606ce155339775bec06d1bfe5e1d7d92eed44a7e317c1611a4')
+sha256sums=('4742fe6a4591572faf75ec0668d0fedf22b3eeff6a9f344372d9edeede3057f5')
 
 package() {
     bsdtar -xf "data.tar.xz"


### PR DESCRIPTION
1. Fix `makepkg --repackage` by extracting `data.tar.xz` at package(). This keeps fast build time by `mv`.
2. Remove wrong space at `install -Dm 644`