### PR TITLE
Define _electron at package()

### DIFF
--- a/packages/windsurf/PKGBUILD
+++ b/packages/windsurf/PKGBUILD
@@ -21,7 +21,7 @@ optdepends=('glib2: Move to trash functionality'
             'libdbusmenu-glib: KDE global menu'
             'lsof: Terminal splitting'
             'vulkan-driver')
-options=('!strip') # for sing  of ext ?
+options=('!strip') # for sing of ext ?
 makedepends=(tar sed desktop-file-utils) # tar is faster than bsdtar.
 source=("https://windsurf-stable.codeiumdata.com/wVxQEIWkwPUEAGf3/apt/pool/main/w/windsurf/Windsurf-linux-x64-${pkgver}.deb"
 		"https://gitlab.archlinux.org/archlinux/packaging/packages/code/-/raw/main/code.sh")
@@ -33,15 +33,10 @@ build() {
 	mv usr/share/{appdata,metainfo}
 	mv usr/share/zsh/{vendor-completions,site-functions}
 	# Launcher
-	_electron=electron$(rg -o -r '$1' '"electron": *"[^0-9]*([0-9]+)' usr/share/windsurf/resources/app/package.json)
-	echo $_electron
-
 	_app=/usr/share/windsurf/resources/app
 	sed -e "s|code-flags|windsurf-flags|" code.sh \
 		-e "s|/usr/lib/code/out/cli.js|${_app}/out/cli.js|" \
 		-e "s|/usr/lib/code/code.mjs|--app=${_app}|" > run.sh
-	sed "s|name=electron|name=${_electron}|" run.sh > run-safe.sh
-
 	ln -sf /usr/bin/windsurf usr/share/windsurf/windsurf
 	# Replacements
 	ln -svf /usr/bin/fd usr/share/windsurf/resources/app/extensions/windsurf/bin/fd
@@ -56,9 +51,10 @@ build() {
 package_windsurf(){
 	pkgdesc="The new purpose-built IDE to harness magic"
 	cp -r --reflink=auto usr "${pkgdir}/usr"
+	_electron=electron$(rg -o -r '$1' '"electron": *"[^0-9]*([0-9]+)' usr/share/windsurf/resources/app/package.json)
+	echo $_electron
+	sed "s|name=electron|name=${_electron}|" run.sh > run-safe.sh
 	install -Dm755 run-safe.sh "${pkgdir}/usr/bin/windsurf"
- 	# redefine is needed
- 	_electron=electron$(rg -o -r '$1' '"electron": *"[^0-9]*([0-9]+)' usr/share/windsurf/resources/app/package.json)
 	depends+=(${_electron}) # hidden from --printsrcinfo
 }
 

--- a/packages/windsurf/PKGBUILD
+++ b/packages/windsurf/PKGBUILD
@@ -57,6 +57,8 @@ package_windsurf(){
 	pkgdesc="The new purpose-built IDE to harness magic"
 	cp -r --reflink=auto usr "${pkgdir}/usr"
 	install -Dm755 run-safe.sh "${pkgdir}/usr/bin/windsurf"
+ 	# redefine is needed
+ 	_electron=electron$(rg -o -r '$1' '"electron": *"[^0-9]*([0-9]+)' usr/share/windsurf/resources/app/package.json)
 	depends+=(${_electron}) # hidden from --printsrcinfo
 }
 


### PR DESCRIPTION
`_electron` is needed to defined at package() to add it to dependency(why?).
Still hidden from `--printsrcinfo` and AUR web interface.