### PR TITLE
fix(windsurf): use correct icon path — upstream removed code-iconsvg.svg

### DIFF
--- a/packages/windsurf/PKGBUILD
+++ b/packages/windsurf/PKGBUILD
@@ -42,8 +42,8 @@ build() {
 	ln -svf /usr/bin/fd usr/share/windsurf/resources/app/extensions/windsurf/bin/fd
 	ln -svf /usr/bin/rg usr/share/windsurf/resources/app/node_modules/@vscode/ripgrep/bin/rg
 	ln -svf /usr/bin/xdg-open usr/share/windsurf/resources/app/node_modules/open/xdg-open
-	# SVG Icon
-	install -Dm644 "usr/share/${pkgname}/resources/app/out/media/code-iconsvg.svg" "usr/share/icons/hicolor/scalable/apps/${pkgname}.svg"
+	# Icon
+	install -Dm644 "usr/share/pixmaps/${pkgname}.png" "usr/share/icons/hicolor/scalable/apps/${pkgname}.png"
 }
 
 package_windsurf(){


### PR DESCRIPTION
## Problem

`build()` fails on current pkgver (2.1.32):

```
install: cannot stat 'usr/share/windsurf/resources/app/out/media/code-iconsvg.svg': No such file or directory
==> ERROR: A failure occurred in build().
```

Upstream no longer ships `out/media/code-iconsvg.svg` in the deb. The file was removed at some point (confirmed by listing the deb contents).

## Fix

Use the PNG icon that upstream actually ships at `usr/share/pixmaps/windsurf.png` instead of the missing SVG.

## Diff

```diff
-	# SVG Icon
-	install -Dm644 "usr/share/${pkgname}/resources/app/out/media/code-iconsvg.svg" "usr/share/icons/hicolor/scalable/apps/${pkgname}.svg"
+	# Icon
+	install -Dm644 "usr/share/pixmaps/${pkgname}.png" "usr/share/icons/hicolor/scalable/apps/${pkgname}.png"
```

## Verified

```
==> Finished making: windsurf 2.1.32-1
```