### PR TITLE
windsurf: fix icon not showing in launchers (PNG in scalable/ → 512x512/)

### DIFF
--- a/packages/windsurf/PKGBUILD
+++ b/packages/windsurf/PKGBUILD
@@ -43,7 +43,7 @@ build() {
 	ln -svf /usr/bin/rg usr/share/windsurf/resources/app/node_modules/@vscode/ripgrep/bin/rg
 	ln -svf /usr/bin/xdg-open usr/share/windsurf/resources/app/node_modules/open/xdg-open
 	# Icon
-	install -Dm644 "usr/share/pixmaps/${pkgname}.png" "usr/share/icons/hicolor/scalable/apps/${pkgname}.png"
+	install -Dm644 "usr/share/pixmaps/${pkgname}.png" "usr/share/icons/hicolor/512x512/apps/${pkgname}.png"
 }
 
 package_windsurf(){


### PR DESCRIPTION
Fixes #166

The current PKGBUILD installs a PNG to `hicolor/scalable/apps/`, which per the [Icon Theme Specification](https://specifications.freedesktop.org/icon-theme-spec/latest/) is reserved for SVG files only. Most launchers (wofi, rofi, tofi) skip PNGs in that directory.

Since upstream no longer ships an SVG icon and only provides a PNG (`usr/share/pixmaps/windsurf.png`, 1024x1024), this changes the install target to `hicolor/512x512/apps/`.

```diff
- install -Dm644 "usr/share/pixmaps/${pkgname}.png" "usr/share/icons/hicolor/scalable/apps/${pkgname}.png"
+ install -Dm644 "usr/share/pixmaps/${pkgname}.png" "usr/share/icons/hicolor/512x512/apps/${pkgname}.png"
```